### PR TITLE
Fix BMI088 Config error by moving config block

### DIFF
--- a/src/imu/bmi088.cpp
+++ b/src/imu/bmi088.cpp
@@ -50,17 +50,11 @@ bool Bmi088::setupBmiSpi() {
   LOG(I, rslt == BMI08_OK, "Accelerometer soft reset.");
   if (rslt != BMI08_OK) { return false; }
 
- // TODO(rikba): Not sure if this step is required.
-
- 
- //----------
- // Issue #19 (YR0th - Yann Roth) This Blockeeds to be here for conifg to load correctly
+ // Issue #19 (YR0th - Yann Roth) This block needs to be here for config to load correctly
  // https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BMI088-accelerometer-noise-too-high/td-p/57674
   rslt = bmi08a_load_config_file(&dev_);
   printErrorCodeResults("bmi08a_load_config_file", rslt);
   if (rslt != BMI08_OK) { return false; }
-  //---------
-
   rslt = bmi08g_soft_reset(&dev_);
   printErrorCodeResults("bmi08g_soft_reset", rslt);
   LOG(I, rslt == BMI08_OK, "Gyroscope soft reset.");


### PR DESCRIPTION
##Solves #19 

Solution to Issue that Accelerometer noise is >1 m/s^2 by running accelerometer config earlier right after accelerometer soft reset. 

This was described and solved by the Bosch Forum in the follwing Issue:
https://community.bosch-sensortec.com/t5/MEMS-sensors-forum/BMI088-accelerometer-noise-too-high/td-p/57674

Linear Accelerations now behave with noise as expected.